### PR TITLE
Chpater11: args name on #method_must_return_kind_of

### DIFF
--- a/Chapter11/03-test-complexity.rb
+++ b/Chapter11/03-test-complexity.rb
@@ -13,8 +13,8 @@ describe Foo do
 end
 
 describe Foo do
-  def method_must_return_kind_of(meth, instance)
-    _(Foo.new.send(meth)).must_be_kind_of(instance)
+  def method_must_return_kind_of(meth, klass)
+    _(Foo.new.send(meth)).must_be_kind_of(klass)
   end
 
   it "should have bar return a Bar instance" do

--- a/Chapter11/chapter-11.rb
+++ b/Chapter11/chapter-11.rb
@@ -127,8 +127,8 @@ end
 # --
 
 describe Foo do
-  def method_must_return_kind_of(meth, instance)
-    _(Foo.new.send(meth)).must_be_kind_of(instance)
+  def method_must_return_kind_of(meth, klass)
+    _(Foo.new.send(meth)).must_be_kind_of(klass)
   end
 
 # --


### PR DESCRIPTION
To make the intension clear, It would be more appropriate `klass`.

